### PR TITLE
Parse KiCad parameters both in JSON format and in the old INI format.

### DIFF
--- a/kicad.py
+++ b/kicad.py
@@ -400,16 +400,18 @@ def getKicadPath(env=''):
     import re
     kicad_common = os.path.join(confpath,'kicad_common')
     if not os.path.isfile(kicad_common):
-        logger.warning('cannot find kicad_common')
-        return None
+        kicad_common += ".json"
+        if not os.path.isfile(kicad_common):
+            logger.warning('cannot find kicad_common')
+            return None
     with open(kicad_common,'r') as f:
         content = f.read()
-    match = re.search(r'^\s*KISYS3DMOD\s*=\s*([^\r\n]+)',content,re.MULTILINE)
+    match = re.search(r'^\s*"*KISYS3DMOD"*\s*[:=]\s*([^\r\n]+)',content,re.MULTILINE)
     if not match:
         logger.warning('no KISYS3DMOD found')
         return None
 
-    return match.group(1).rstrip(' ')
+    return match.group(1).rstrip(' "')
 
 _model_cache = {}
 


### PR DESCRIPTION
KiCad v5.99 (at least) uses config file kicad_common.json which looks like this:
  ====
  "environment": {
    "show_warning_dialog": false,
    "vars": {
      "KICAD6_3DMODEL_DIR": "/usr/local/share/kicad/3dmodels/",
      "KICAD6_FOOTPRINT_DIR": "/usr/local/share/kicad/modules",
      "KICAD6_SYMBOL_DIR": "/usr/local/share/kicad/library",
      "KICAD6_TEMPLATE_DIR": "/usr/local/share/kicad/template",
      "KICAD_3DMODEL_DIR": "/usr/local/share/kicad/3dmodels/",
      "KICAD_FOOTPRINT_DIR": "/usr/local/share/kicad/modules",
      "KICAD_SYMBOL_DIR": "/usr/local/share/kicad/library",
      "KICAD_TEMPLATE_DIR": "/usr/local/share/kicad/template",
      "KICAD_USER_TEMPLATE_DIR": "/home/rabbit/kicad/5.99/template",
      "KISYS3DMOD": "/usr/local/share/kicad/modules/packages3d/",
      "KISYSMOD": "/usr/local/share/kicad/modules"
    }
  },
  ==== 
  commit e59a3d981e780435f7da1e71c538818718b8d67c
  Author: Jon Evans <jon@craftyjon.com>
  Date:   Sun Jan 12 20:44:19 2020 -0500
    Implement a new settings framework across all of KiCad
    CHANGED: Settings are now stored in versioned sub-directories
    ...
    CHANGED: Settings are now stored as JSON files instead of wxConfig-style INI files
    ...

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>